### PR TITLE
Update db to larger int value to save customalert settings properly

### DIFF
--- a/Model.php
+++ b/Model.php
@@ -41,7 +41,7 @@ class Model
 			`metric` VARCHAR(150) NOT NULL ,
 			`metric_condition` VARCHAR(50) NOT NULL ,
 			`metric_matched` FLOAT NOT NULL ,
-			`compared_to` TINYINT NOT NULL DEFAULT 1 ,
+			`compared_to` SMALLINT NOT NULL DEFAULT 1 ,
 			`email_me` BOOLEAN NOT NULL ,
 			`additional_emails` TEXT DEFAULT '' ,
 			`phone_numbers` TEXT DEFAULT ''
@@ -70,7 +70,7 @@ class Model
 			`metric` VARCHAR(150) NOT NULL ,
 			`metric_condition` VARCHAR(50) NOT NULL ,
 			`metric_matched` FLOAT NOT NULL ,
-			`compared_to` TINYINT NOT NULL DEFAULT 1 ,
+			`compared_to` SMALLINT NOT NULL DEFAULT 1 ,
 			`email_me` BOOLEAN NOT NULL ,
 			`additional_emails` TEXT DEFAULT '' ,
 			`phone_numbers` TEXT DEFAULT '',

--- a/Updates/0.1.8.php
+++ b/Updates/0.1.8.php
@@ -19,12 +19,13 @@ use Piwik\Updates;
 /**
  * @package Updates
  */
-class Updates_0_0_9 extends Updates
+class Updates_0_1_8 extends Updates
 {
     static function getSql($schema = 'Myisam')
     {
         return array(
-            "ALTER TABLE `" . Common::prefixTable('alert_log') . "` CHANGE `compared_to` `compared_to` SMALLINT( 4 ) NOT NULL DEFAULT '1'" => 1060,
+            "ALTER TABLE `" . Common::prefixTable('alert_triggered') . "` CHANGE `compared_to` `compared_to` SMALLINT( 4 ) NOT NULL DEFAULT 1" => 1060,
+            "ALTER TABLE `" . Common::prefixTable('alert') . "` CHANGE `compared_to` `compared_to` SMALLINT( 4 ) NOT NULL DEFAULT 1" => 1060,
         );
     }
 


### PR DESCRIPTION
Tinyint will not correctly save when comparing to year is used.
