### PR TITLE
Fix idSites validation in getAlerts method

### DIFF
--- a/API.php
+++ b/API.php
@@ -92,11 +92,12 @@ class API extends \Piwik\Plugin\API
      */
 	public function getAlerts($idSites, $ifSuperUserReturnAllAlerts = false)
 	{
+        $idSites = Site::getIdSitesFromIdSitesString($idSites);
+
         if (empty($idSites)) {
             return array();
         }
 
-        $idSites = Site::getIdSitesFromIdSitesString($idSites);
         Piwik::checkUserHasViewAccess($idSites);
 
         if (Piwik::hasUserSuperUserAccess() && $ifSuperUserReturnAllAlerts) {


### PR DESCRIPTION
The `empty` check for `idSites` needs to be done after filtering the value.
Otherwise if `idSites` contains only invalid values, it results in a SQL error.