### PR TITLE
Use registerEvents instead of getListHooksRegistered, as it is deprecated

### DIFF
--- a/CustomAlerts.php
+++ b/CustomAlerts.php
@@ -21,7 +21,7 @@ use Piwik\Plugins\SitesManager\API as SitesManagerApi;
 class CustomAlerts extends \Piwik\Plugin
 {
 
-	public function getListHooksRegistered()
+	public function registerEvents()
 	{
 		return array(
 		    'MobileMessaging.deletePhoneNumber' => 'removePhoneNumberFromAllAlerts',


### PR DESCRIPTION
`getListHooksRegistered` is deprecated since Piwik 2.15. So should be safe to merge directly.