### PR TITLE
Fix setting title attribute

### DIFF
--- a/angularjs/managecustomalerts/managecustomalerts.controller.js
+++ b/angularjs/managecustomalerts/managecustomalerts.controller.js
@@ -149,11 +149,11 @@
             this.isComparable = condition && -1 !== condition.indexOf('_more_than');
 
             if (isPercentageCondition || isPercentageMetric) {
-                $('.metricValueDescription').text('%');
+                $('[name=metricValue]').attr('title', '%');
             } else if (isSecondsMetric) {
-                $('.metricValueDescription').text('s');
+                $('[name=metricValue]').attr('title', 's');
             } else {
-                $('.metricValueDescription').text(_pk_translate('General_Value'));
+                $('[name=metricValue]').attr('title', _pk_translate('General_Value'));
             }
         }
         

--- a/templates/form.twig
+++ b/templates/form.twig
@@ -128,7 +128,6 @@
             <div class="col s12 m6">
                 <div piwik-field uicontrol="text" name="metricValue"
                      ng-model="manageAlerts.alert.metricValue"
-                     title="<span class='metricValueDescription'></span>"
                      full-width="true"
                      {% if alert %}value="{{ alert.metric_matched|e('html_attr') }}"{% endif %} >
                 </div>


### PR DESCRIPTION
As no tooltip is used here, the title attribute currently contains `<span class='metricValueDescription'></span>` and isn't replaced correctly.