### PR TITLE
Group reports into categories when creating a new custom alert

### DIFF
--- a/angularjs/managecustomalerts/managecustomalerts.controller.js
+++ b/angularjs/managecustomalerts/managecustomalerts.controller.js
@@ -81,7 +81,7 @@
                     self.alert.report = reportApiMethod;
                 }
 
-                options.push({key: reportApiMethod, value: reportMetadata.name});
+                options.push({key: reportApiMethod, value: reportMetadata.name, group: reportMetadata.category});
 
                 if (reportApiMethod == self.alert.report) {
                     updateMetrics(reportMetadata.metrics);


### PR DESCRIPTION
### Description:

Before the dropdown was simply showing a really long list of reports (hundreds with all the premium feature and many goals and forms) vs now there are at least some categories that help make it a little bit easier to find the correct report. 

![image](https://user-images.githubusercontent.com/273120/129131219-e1c9dfa1-96e8-4c2c-82d7-bbbbc190bf9e.png)

Ideally we would use the expandable-select which is easy to do but would require tests and it's not as much of a priority. Created https://github.com/matomo-org/plugin-CustomAlerts/issues/90 as a follow up.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
