### PR TITLE
Fix Autocomplete proposes localized values (e.g. Country), that don't work to trigger alerts

### DIFF
--- a/angularjs/managecustomalerts/managecustomalerts.controller.js
+++ b/angularjs/managecustomalerts/managecustomalerts.controller.js
@@ -248,6 +248,7 @@
                 flat: 1,
                 filter_limit: -1,
                 showColumns: metric,
+                language: 'en',
                 apiModule: apiModule,
                 apiAction: apiAction,
                 idSite: self.alert.site.id,


### PR DESCRIPTION

### Description:

fix https://github.com/matomo-org/plugin-CustomAlerts/issues/113

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
