### PR TITLE
Adding check for whether reports used by alert are done archiving

### DIFF
--- a/Model.php
+++ b/Model.php
@@ -194,6 +194,23 @@ class Model
         return $alerts;
     }
 
+    public function getTriggeredAlertsFromPastNHours(string $period, int $idSite, int $hours)
+    {
+        $timestamp = Date::now()->addHour(-1 * $hours)->getDatetime();
+
+        $db  = $this->getDb();
+        $sql = $this->getTriggeredAlertsSelectPart()
+            . " WHERE idsite = ?"
+            . " AND  period = ?"
+            . " AND  ts_triggered > ?";
+
+        $values = [$idSite, $period, $timestamp];
+
+        $alerts = $db->fetchAll($sql, $values);
+
+        return $this->completeAlerts($alerts);
+    }
+
     public function getAllAlerts()
     {
         $sql = "SELECT * FROM " . Common::prefixTable('alert');

--- a/Processor.php
+++ b/Processor.php
@@ -16,6 +16,7 @@ use Piwik\Context;
 use Piwik\DataTable;
 use Piwik\Date;
 use Piwik\Option;
+use Piwik\Piwik;
 use Piwik\Plugins\API\ProcessedReport;
 use Piwik\Scheduler\RetryableException;
 use Piwik\Site;
@@ -117,7 +118,7 @@ class Processor
                 $this->processAlert($alert, $idSite);
             } catch (RetryableException $e) {
                 if (intval($retryCount) === 3) {
-                    StaticContainer::get(\Piwik\Log\LoggerInterface::class)->warning("Final retry of alerts task. Unable to process the following alert: {$alert['name']}.");
+                    StaticContainer::get(\Piwik\Log\LoggerInterface::class)->warning(Piwik::translate('CustomAlerts_FinalTaskRetryWarning', [$alert['name']]));
                 }
 
                 throw $e;
@@ -294,7 +295,7 @@ class Processor
         }
 
         // Throw an exception since the archive status was provided and isn't complete
-        throw new RetryableException("The alert '{$alert['name']}' is unable to process because archiving is not complete for report: {$alert['report']}.");
+        throw new RetryableException(Piwik::translate('CustomAlerts_TaskRetryExceptionMessage', [$alert['name'], $alert['report']]));
     }
 
     private function getDateForAlertInPast($idSite, $period, $subPeriodN)

--- a/Processor.php
+++ b/Processor.php
@@ -181,7 +181,7 @@ class Processor
         }
     }
 
-    protected function shouldBeProcessed($alert, $idSite)
+    private function shouldBeProcessed($alert, $idSite)
     {
         if (empty($alert['id_sites']) || !in_array($idSite, $alert['id_sites'])) {
             return false;
@@ -238,7 +238,7 @@ class Processor
             'date'                   => $dateInPast,
             'flat'                   => 1,
             'disable_queued_filters' => 1,
-            'filter_limit'           => -1,
+            'filter_limit'           => -1
         );
 
         // Only include the archive state param for versions of Matomo that allow it

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,8 @@
         "ValuePercentageIncreasedMoreThan": "increased more than %1$s%% from %2$s to %3$s",
         "WeekComparedToPreviousWeek": "previous week",
         "When": "when",
-        "YouCanChoosePeriodFrom": "You can choose from the following options"
+        "YouCanChoosePeriodFrom": "You can choose from the following options",
+        "TaskRetryExceptionMessage": "The alert '%1$s' is unable to process because archiving is not complete for report '%2$s'",
+        "FinalTaskRetryWarning": "Final retry of alerts task. Unable to process the following alert: %1$s"
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -72,7 +72,7 @@
         "WeekComparedToPreviousWeek": "previous week",
         "When": "when",
         "YouCanChoosePeriodFrom": "You can choose from the following options",
-        "TaskRetryExceptionMessage": "The alert '%1$s' is unable to process because archiving is not complete for report '%2$s'",
-        "FinalTaskRetryWarning": "Final retry of alerts task. Unable to process the following alert: %1$s"
+        "TaskRetryExceptionMessage": "The following alerts were unable to process because archiving is not complete for the associated reports: %1$s",
+        "FinalTaskRetryWarning": "Final retry of alerts task. Unable to process the following alerts: %1$s"
     }
 }

--- a/tests/Integration/ModelTest.php
+++ b/tests/Integration/ModelTest.php
@@ -411,4 +411,67 @@ class ModelTest extends BaseTest
         $this->assertEquals(3, $alerts[1]['idtriggered']);
     }
 
+    public function testGetTriggeredAlertsFromPastNHours()
+    {
+        $now = Date::now();
+        $this->model->triggerAlert(1, 1, 99, 48, $now->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-1)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-1)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-1)->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-2)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-2)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-2)->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-3)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-3)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-3)->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-4)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-4)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-4)->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-5)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-5)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-5)->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-6)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-6)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-6)->getDatetime());
+        $this->model->triggerAlert(1, 1, 99, 48, $now->addHour(-7)->getDatetime());
+        $this->model->triggerAlert(1, 2, 99, 48, $now->addHour(-7)->getDatetime());
+        $this->model->triggerAlert(1, 3, 99, 48, $now->addHour(-7)->getDatetime());
+
+        // Test looking up only the latest 2 triggered alerts
+        $alerts = $this->model->getTriggeredAlertsFromPastNHours('day', 1, 2);
+        $this->assertCount(2, $alerts);
+
+        $this->assertEquals(1, $alerts[0]['idtriggered']);
+        $this->assertEquals(4, $alerts[1]['idtriggered']);
+
+        // Test looking up the latest 6 triggered alerts
+        $alerts = $this->model->getTriggeredAlertsFromPastNHours('day', 1, 6);
+        $this->assertCount(6, $alerts);
+
+        $this->assertEquals(1, $alerts[0]['idtriggered']);
+        $this->assertEquals(4, $alerts[1]['idtriggered']);
+        $this->assertEquals(7, $alerts[2]['idtriggered']);
+        $this->assertEquals(10, $alerts[3]['idtriggered']);
+        $this->assertEquals(13, $alerts[4]['idtriggered']);
+        $this->assertEquals(16, $alerts[5]['idtriggered']);
+
+        // Test looking up the latest triggered alerts for a different site
+        $alerts = $this->model->getTriggeredAlertsFromPastNHours('day', 2, 4);
+        $this->assertCount(4, $alerts);
+
+        $this->assertEquals(2, $alerts[0]['idtriggered']);
+        $this->assertEquals(5, $alerts[1]['idtriggered']);
+        $this->assertEquals(8, $alerts[2]['idtriggered']);
+        $this->assertEquals(11, $alerts[3]['idtriggered']);
+
+        // Test looking up the latest triggered alerts for the last site
+        $alerts = $this->model->getTriggeredAlertsFromPastNHours('day', 3, 3);
+        $this->assertCount(3, $alerts);
+
+        $this->assertEquals(3, $alerts[0]['idtriggered']);
+        $this->assertEquals(6, $alerts[1]['idtriggered']);
+        $this->assertEquals(9, $alerts[2]['idtriggered']);
+    }
 }

--- a/tests/Integration/ProcessorTest.php
+++ b/tests/Integration/ProcessorTest.php
@@ -663,7 +663,7 @@ class ProcessorTest extends BaseTest
         $mockProcessor->__construct();
 
         $loggerMock = $this->createMock(LoggerInterface::class);
-        $loggerMock->expects($this->once())->method('warning')->with($this->equalTo('Final retry of alerts task. Unable to process the following alert: TestAlert1.'));
+        $loggerMock->expects($this->once())->method('warning')->with($this->equalTo('CustomAlerts_FinalTaskRetryWarning'));
         StaticContainer::getContainer()->set(LoggerInterface::class, $loggerMock);
 
         $this->expectException(RetryableException::class);

--- a/tests/Integration/ProcessorTest.php
+++ b/tests/Integration/ProcessorTest.php
@@ -196,7 +196,7 @@ class ProcessorTest extends BaseTest
 
     public function testGetValueForAlertInPastIncompleteArchive()
     {
-        // Use today's date so that the archiving shows as complete for the report
+        // Use today's date so that the archiving shows as incomplete for the report
         $date = Date::today();
 
         $t = Fixture::getTracker($this->idSite, $date->getDatetime(), $defaultInit = true);
@@ -239,8 +239,15 @@ class ProcessorTest extends BaseTest
         $this->assertNull($result);
 
         // Should throw an exception if the archive state is incomplete
-        $this->expectException(RetryableException::class);
-        $this->processor->getValueForAlertInPast($alert, $this->idSite, 0);
+        $isNewEnoughMatomo = version_compare(\Piwik\Version::VERSION, '5.1.0-b1', '>=');
+        if ($isNewEnoughMatomo) {
+            $this->expectException(RetryableException::class);
+        }
+        $value = $this->processor->getValueForAlertInPast($alert, $this->idSite, 0);
+
+        if (!$isNewEnoughMatomo) {
+            $this->assertEquals(3, $value, $alert['metric'] . ':' . $alert['report_matched'] . ' should return value 3 but returns ' . $value);
+        }
     }
 
     public function test_filterDataTable_Condition_DoesNotMatchExactly()

--- a/tests/Integration/ProcessorTest.php
+++ b/tests/Integration/ProcessorTest.php
@@ -14,6 +14,7 @@ use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Date;
 use Piwik\Plugins\CustomAlerts\Processor;
+use Piwik\Scheduler\RetryableException;
 use Piwik\Tests\Framework\Fixture;
 
 class CustomProcessor extends Processor
@@ -118,7 +119,8 @@ class ProcessorTest extends BaseTest
 
     public function test_filterDataTable_MatchesExactlyIntegration()
     {
-        $date = Date::today()->addHour(10);
+        // Use yesterday's date so that the archiving shows as complete for the report
+        $date = Date::yesterday();
 
         $t = Fixture::getTracker($this->idSite, $date->getDatetime(), $defaultInit = true);
         $t->enableBulkTracking();
@@ -177,10 +179,59 @@ class ProcessorTest extends BaseTest
                 'report_matched'   => Common::sanitizeInputValue($assert[1])
             );
 
-            $value = $this->processor->getValueForAlertInPast($alert, $this->idSite, 0);
+            $value = $this->processor->getValueForAlertInPast($alert, $this->idSite, 1);
 
             $this->assertEquals($assert[2], $value, $assert[0] . ':' . $assert[1] . ' should return value ' . $assert[2] . ' but returns ' . $value);
         }
+    }
+
+    public function testGetValueForAlertInPastIncompleteArchive()
+    {
+        // Use yesterday's date so that the archiving shows as complete for the report
+        $date = Date::today();
+
+        $t = Fixture::getTracker($this->idSite, $date->getDatetime(), $defaultInit = true);
+        $t->enableBulkTracking();
+
+        $t->setUrlReferrer('http://www.google.com.vn/url?sa=t&rct=j&q=%3C%3E%26%5C%22the%20pdo%20extension%20is%20required%20for%20this%20adapter%20but%20the%20extension%20is%20not%20loaded&source=web&cd=4&ved=0FjAD&url=http%3A%2F%2Fforum.piwik.org%2Fread.php%3F2%2C1011&ei=y-HHAQ&usg=AFQjCN2-nt5_GgDeg&cad=rja');
+        $t->setUrl('http://example.org/%C3%A9%C3%A9%C3%A9%22%27...%20%3Cthis%20is%20cool%3E!');
+        $t->doTrackPageView('incredible title! <>,;');
+
+        $t->setForceVisitDateTime($date->addHour(.1)->getDatetime());
+        $t->setUrl('http://example.org/dir/file.php?foo=bar&foo2=bar');
+        $t->setPerformanceTimings(0, 123, 234, 345, 456, 567);
+        $t->doTrackPageView('incredible title! <>,;');
+
+        $t->setForceVisitDateTime($date->addHour(.2)->getDatetime());
+        $t->setUrl('http://example.org/dir/file/xyz.php?foo=bar&foo2=bar');
+        $t->doTrackPageView('incredible title! <>,;');
+
+        $t->setForceVisitDateTime($date->addHour(.2)->getDatetime());
+        $t->setUrl('http://example.org/what-is-piwik');
+        $t->doTrackPageView('incredible title! <>,;');
+
+        $t->setForceVisitDateTime($date->addHour(.3)->getDatetime());
+        $t->setUrl('http://example.org/dir/file.php?foo=bar&foo2=bar');
+        $t->doTrackPageView('incredible title! <>,;');
+
+        Fixture::checkBulkTrackingResponse($t->doBulkTrack());
+
+        $alert = [
+            'name'             => 'Test alert name',
+            'report'           => 'Actions_getPageUrls',
+            'metric'           => 'nb_hits',
+            'period'           => 'day',
+            'report_condition' => 'contains',
+            'report_matched'   => 'foo'
+        ];
+
+        // Should just return no data if the archive status isn't present
+        $result = $this->processor->getValueForAlertInPast($alert, $this->idSite, 1);
+        $this->assertNull($result);
+
+        // Should throw an exception if the archive state is incomplete
+        $this->expectException(RetryableException::class);
+        $this->processor->getValueForAlertInPast($alert, $this->idSite, 0);
     }
 
     public function test_filterDataTable_Condition_DoesNotMatchExactly()


### PR DESCRIPTION
### Description:

Adding check for whether reports used by alert are done archiving. This is to prevent alerts being sent based on incomplete data. This means that if the report that the alert depends on isn't done archiving, the task will be scheduled to retry again in an hour, up to 3 times (hard coded in the Core Scheduler class).

**NOTE:** The archive status check and retry will only work for Matomo 5.1.0-b1 forward because that's when the archive state was added as on optional metadata field, but I believe that I've coded the changes so that it won't cause issues for older Matomo versions.

To test that the new retry is working as expected I did the following:
- Create an alert that compares the visits of the day to the previous day
- Have some visits recorded for yesterday
- Invalidate the archives for yesterday so that the report shows as archiving incomplete
- Use the `./console core:run-scheduled-tasks --force` command to run the scheduled tasks. I tried providing the task class in the command, but that prevents the retry from being scheduled. So, you have to run all tasks and search through the output for the daily CustomAlert task. It should show an error message noting that it will retry.
- Either run the task so that it retries the 3 allowed times or run archiving again so that the report no longer shows as incomplete and the task processes without errors. Any alerts recorded in the `alert_triggered` table will not be processed again on retries.

Internal ticket: PG-3685
Related Github Issue: https://github.com/matomo-org/matomo/issues/21499

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
