### PR TITLE
Fix PHPUnit deprecation warnings in integration tests

### DIFF
--- a/tests/Integration/NotifierTest.php
+++ b/tests/Integration/NotifierTest.php
@@ -211,67 +211,50 @@ Hello,=0A=0AThe triggered alerts are listed in the table below. To adjust y=';
 
         $mock->setTriggeredAlerts($alerts);
 
-        $mock->expects($this->at(0))
+        $expectedEmailCalls = [
+            [$alerts, 'test5@example.com'],
+            [[$alerts[0], $alerts[2]], 'test1@example.com'],
+            [[$alerts[1]], 'test2@example.com'],
+            [[$alerts[3]], 'test3@example.com'],
+        ];
+        $mock->expects($this->exactly(count($expectedEmailCalls)))
             ->method('sendAlertsPerEmailToRecipient')
-            ->with(
-                $this->equalTo($alerts),
-                $this->isInstanceOf('\Piwik\Mail'),
-                $this->equalTo('test5@example.com'),
-                $this->equalTo($period),
-                $this->equalTo($idSite)
-            );
+            ->willReturnCallback(function ($actualAlerts, $mail, $recipient, $actualPeriod, $actualIdSite) use (&$expectedEmailCalls, $period, $idSite) {
+                [$expectedAlerts, $expectedRecipient] = array_shift($expectedEmailCalls);
 
-        $mock->expects($this->at(1))
-            ->method('sendAlertsPerEmailToRecipient')
-            ->with(
-                $this->equalTo(array($alerts[0], $alerts[2])),
-                $this->isInstanceOf('\Piwik\Mail'),
-                $this->equalTo('test1@example.com'),
-                $this->equalTo($period),
-                $this->equalTo($idSite)
-            );
+                $this->assertSame($expectedAlerts, $actualAlerts);
+                $this->assertInstanceOf('\Piwik\Mail', $mail);
+                $this->assertSame($expectedRecipient, $recipient);
+                $this->assertSame($period, $actualPeriod);
+                $this->assertSame($idSite, $actualIdSite);
+            });
 
-        $mock->expects($this->at(2))
-            ->method('sendAlertsPerEmailToRecipient')
-            ->with(
-                $this->equalTo(array($alerts[1])),
-                $this->isInstanceOf('\Piwik\Mail'),
-                $this->equalTo('test2@example.com'),
-                $this->equalTo($period),
-                $this->equalTo($idSite)
-            );
-
-        $mock->expects($this->at(3))
-            ->method('sendAlertsPerEmailToRecipient')
-            ->with(
-                $this->equalTo(array($alerts[3])),
-                $this->isInstanceOf('\Piwik\Mail'),
-                $this->equalTo('test3@example.com'),
-                $this->equalTo($period),
-                $this->equalTo($idSite)
-            );
-
-        $mock->expects($this->at(4))
+        $expectedSmsCalls = [
+            [[$alerts[0], $alerts[1], $alerts[3]], '+1234567890'],
+            [$alerts, '232'],
+        ];
+        $mock->expects($this->exactly(count($expectedSmsCalls)))
             ->method('sendAlertsPerSmsToRecipient')
-            ->with(
-                $this->equalTo(array($alerts[0], $alerts[1], $alerts[3])),
-                $this->isInstanceOf('\Piwik\Plugins\MobileMessaging\Model'),
-                $this->equalTo('+1234567890')
-            );
+            ->willReturnCallback(function ($actualAlerts, $mobileMessagingModel, $phoneNumber) use (&$expectedSmsCalls) {
+                [$expectedAlerts, $expectedPhoneNumber] = array_shift($expectedSmsCalls);
 
-        $mock->expects($this->at(5))
-            ->method('sendAlertsPerSmsToRecipient')
-            ->with(
-                $this->equalTo($alerts),
-                $this->isInstanceOf('\Piwik\Plugins\MobileMessaging\Model'),
-                $this->equalTo('232')
-            );
+                $this->assertSame($expectedAlerts, $actualAlerts);
+                $this->assertInstanceOf('\Piwik\Plugins\MobileMessaging\Model', $mobileMessagingModel);
+                $this->assertEquals($expectedPhoneNumber, $phoneNumber);
+            });
 
-        foreach ($alerts as $index => $alert) {
-            $mock->expects($this->at(6 + $index))->method('markAlertAsSent')->with($this->equalTo($alert));
-        }
+        $expectedMarkedAlerts = $alerts;
+        $mock->expects($this->exactly(count($expectedMarkedAlerts)))
+            ->method('markAlertAsSent')
+            ->willReturnCallback(function ($actualAlert) use (&$expectedMarkedAlerts) {
+                $this->assertSame(array_shift($expectedMarkedAlerts), $actualAlert);
+            });
 
         $mock->sendNewAlerts($period, $idSite);
+
+        $this->assertSame([], $expectedEmailCalls);
+        $this->assertSame([], $expectedSmsCalls);
+        $this->assertSame([], $expectedMarkedAlerts);
     }
 
     public function provideContainerConfig()

--- a/tests/Integration/ProcessorTest.php
+++ b/tests/Integration/ProcessorTest.php
@@ -488,45 +488,53 @@ class ProcessorTest extends BaseTest
             ->getMock();
 
         $idSite = 1;
-        $processorMock->expects($this->at(0))
+        $expectedGetValueCalls = [
+            [$alert, $idSite, 1, 13],
+            [$alert, $idSite, 13, 10],
+        ];
+        $processorMock->expects($this->exactly(count($expectedGetValueCalls)))
             ->method('getValueForAlertInPast')
-            ->with($this->equalTo($alert), $this->equalTo($idSite), $this->equalTo(1))
-            ->will($this->returnValue(13));
+            ->willReturnCallback(function ($actualAlert, $actualIdSite, $actualSubPeriodN) use (&$expectedGetValueCalls) {
+                [$expectedAlert, $expectedIdSite, $expectedSubPeriodN, $returnValue] = array_shift($expectedGetValueCalls);
 
-        $processorMock->expects($this->at(1))
-            ->method('getValueForAlertInPast')
-            ->with($this->equalTo($alert), $this->equalTo($idSite), $this->equalTo(13))
-            ->will($this->returnValue(10));
+                $this->assertSame($expectedAlert, $actualAlert);
+                $this->assertSame($expectedIdSite, $actualIdSite);
+                $this->assertSame($expectedSubPeriodN, $actualSubPeriodN);
+
+                return $returnValue;
+            });
 
         $processorMock->expects($this->never())->method('triggerAlert');
 
-        $processorMock->expects($this->exactly(2))
-            ->method('getValueForAlertInPast');
-
         $processorMock->processAlert($alert, $idSite);
+        $this->assertSame([], $expectedGetValueCalls);
 
         $idSite        = 2;
         $processorMock = $this->getMockBuilder('Piwik\Plugins\CustomAlerts\tests\Integration\CustomProcessor')
             ->setMethods($methods)
             ->getMock();
-        $processorMock->expects($this->at(0))
+        $expectedGetValueCalls = [
+            [$alert, $idSite, 1, 15],
+            [$alert, $idSite, 13, 10],
+        ];
+        $processorMock->expects($this->exactly(count($expectedGetValueCalls)))
             ->method('getValueForAlertInPast')
-            ->with($this->equalTo($alert), $this->equalTo($idSite), $this->equalTo(1))
-            ->will($this->returnValue(15));
+            ->willReturnCallback(function ($actualAlert, $actualIdSite, $actualSubPeriodN) use (&$expectedGetValueCalls) {
+                [$expectedAlert, $expectedIdSite, $expectedSubPeriodN, $returnValue] = array_shift($expectedGetValueCalls);
 
-        $processorMock->expects($this->at(1))
-            ->method('getValueForAlertInPast')
-            ->with($this->equalTo($alert), $this->equalTo($idSite), $this->equalTo(13))
-            ->will($this->returnValue(10));
+                $this->assertSame($expectedAlert, $actualAlert);
+                $this->assertSame($expectedIdSite, $actualIdSite);
+                $this->assertSame($expectedSubPeriodN, $actualSubPeriodN);
 
-        $processorMock->expects($this->exactly(2))
-            ->method('getValueForAlertInPast');
+                return $returnValue;
+            });
 
         $processorMock->expects($this->once())
             ->method('triggerAlert')
             ->with($this->equalTo($alert), $this->equalTo($idSite), $this->equalTo(15), $this->equalTo(10));
 
         $processorMock->processAlert($alert, $idSite);
+        $this->assertSame([], $expectedGetValueCalls);
     }
 
     private function buildAlert(
@@ -603,20 +611,27 @@ class ProcessorTest extends BaseTest
         $processorMock = $this->getMockBuilder('Piwik\Plugins\CustomAlerts\tests\Integration\CustomProcessor')
             ->setMethods($methods)
             ->getMock();
-        $processorMock->expects($this->at(0))
+        $expectedGetValueCalls = [
+            [$alert, 1, 1, 15],
+            [$alert, 1, 8, 10],
+        ];
+        $processorMock->expects($this->exactly(count($expectedGetValueCalls)))
             ->method('getValueForAlertInPast')
-            ->with($this->equalTo($alert), $this->equalTo(1), $this->equalTo(1))
-            ->will($this->returnValue(15));
+            ->willReturnCallback(function ($actualAlert, $actualIdSite, $actualSubPeriodN) use (&$expectedGetValueCalls) {
+                [$expectedAlert, $expectedIdSite, $expectedSubPeriodN, $returnValue] = array_shift($expectedGetValueCalls);
 
-        $processorMock->expects($this->at(1))
-            ->method('getValueForAlertInPast')
-            ->with($this->equalTo($alert), $this->equalTo(1), $this->equalTo(8))
-            ->will($this->returnValue(10));
+                $this->assertSame($expectedAlert, $actualAlert);
+                $this->assertSame($expectedIdSite, $actualIdSite);
+                $this->assertSame($expectedSubPeriodN, $actualSubPeriodN);
+
+                return $returnValue;
+            });
 
         $processorMock->expects($this->never())
             ->method('triggerAlert');
 
         $processorMock->processAlert($alert, 1);
+        $this->assertSame([], $expectedGetValueCalls);
     }
 
     public function test_shouldBeTriggered_ShouldFail_IfInvalidConditionGiven()


### PR DESCRIPTION
## Description

This PR removes PHPUnit deprecation warnings in affected integration tests to improve PHPUnit 10 compatibility.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
