### PR TITLE
Adds escaping for report_matched value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* 5.2.5 - 2026-03-30 - Added escaping for report_matched value
 * 5.2.4 - 2026-03-02 - Updated API documentation
 * 5.2.3 - 2026-02-05 - Alerts now get deleted when a user's site access is revoked
 * 5.2.2 - 2026-01-19 - Added tooltips in add/edit alerts, manage alerts & in the inline text for the delivery method 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "CustomAlerts",
     "description": "Create custom Alerts to be notified of important changes on your website or app! ",
-    "version": "5.2.4",
+    "version": "5.2.5",
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"
     },

--- a/templates/htmlTriggeredAlerts.twig
+++ b/templates/htmlTriggeredAlerts.twig
@@ -29,7 +29,7 @@
         {% endif %}
         <td style="{% if not extended %}{{styleTableCell}}{% else %}max-width:300px;{% endif %}{{ style }}">{{ alert.reportName|default(alert.report)|rawSafeDecoded }}</td>
 {% if hasConditions %}
-        <td style="{% if not extended %}{{styleTableCell}}{% else %}max-width:300px;{% endif %}{{ style }}">{{ alert.dimension|default('') }} {{ alert.reportConditionName }} {% if alert.report_matched %}'{{ alert.report_matched|truncate(100)|raw }}'{% endif %}</td>
+        <td style="{% if not extended %}{{styleTableCell}}{% else %}max-width:300px;{% endif %}{{ style }}">{{ alert.dimension|default('') }} {{ alert.reportConditionName }} {% if alert.report_matched %}'{{ alert.report_matched|truncate(100)|rawSafeDecoded }}'{% endif %}</td>
 {% endif %}
         <td style="{% if not extended %}{{styleTableCell}}{% else %}max-width:300px;{% endif %}{{ style }}padding:17px 10px;">{{ alert.reportMetric }} {{ alertsMacro.metricChangeDescription(alert) }}</td>
     </tr>

--- a/tests/Integration/ControllerTest.php
+++ b/tests/Integration/ControllerTest.php
@@ -228,6 +228,20 @@ FORMATTED;
         $this->assertEquals($expected, $rendered, "Got following HTML response: " . var_export($rendered, true));
     }
 
+    public function test_formatAlerts_asHtml_shouldEscapeReportMatched()
+    {
+        $payload = '<img src=x onerror=alert(1)>';
+        $alerts = array(
+            $this->buildAlert(1, 'MyName1', 'week', 1, 'Piwik test', 'superUserLogin', 'nb_visits', 'decrease_more_than', 5000, 'MultiSites_getOne', 'matches_exactly', $payload)
+        );
+
+        $rendered = $this->controller->formatAlerts($alerts, 'html');
+
+        $this->assertStringContainsString("Website is '&lt;img src=x onerror=alert(1)&gt;'", $rendered);
+        $this->assertStringNotContainsString("'{$payload}'", $rendered);
+        $this->assertStringNotContainsString("<img src=x onerror=alert(1)>", $rendered);
+    }
+
     public function test_enrichTriggeredAlerts_shouldEnrichAlerts_IfReportExistsAndMetricIsValid()
     {
         $timestamp = 1389824417;


### PR DESCRIPTION
## Description
Adds escaping for report_matched value

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
