### PR TITLE
Escape percent sign in translation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -7,7 +7,7 @@
         "AlertMeWhen": "Alert me when",
         "AlertDescriptionOptional": "Description (optional)",
         "AlertDescriptionInlineHelp": "Enter a description to provide additional context, such as the purpose or usage.",
-        "AlertDescriptionPlaceholder": "Alert me when visits decrease by 40%",
+        "AlertDescriptionPlaceholder": "Alert me when visits decrease by 40%%",
         "AlertName": "Alert Name",
         "AlertNameInlineHelp": "Enter a unique name to clearly identify this custom alert.",
         "AlertNamePlaceholder": "Visits drop detected",


### PR DESCRIPTION
## Description

We should always escape percent signs in translations, to ensure they won't break the `sprintf`

Note: This currently let's core tests for translations fail: https://github.com/matomo-org/matomo/pull/24576


## Checklist
- [✖] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [✔] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
