### PR TITLE
Adds code to improve the access check before sending an alert, #AS-586

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* 5.3.1 - 2026-06-29 - Added code to improve the access check before sending an alert
 * 5.3.1 - 2026-06-08 - Added restrict access check for MultiSites.getAll report for non superusers
 * 5.3.0 - 2026-05-11 - Added alert description and helptexts
 * 5.2.6 - 2026-04-27 - Updated API documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-* 5.3.1 - 2026-06-29 - Added code to improve the access check before sending an alert
+* 5.3.2 - 2026-06-29 - Added code to improve the access check before sending an alert
 * 5.3.1 - 2026-06-08 - Added restrict access check for MultiSites.getAll report for non superusers
 * 5.3.0 - 2026-05-11 - Added alert description and helptexts
 * 5.2.6 - 2026-04-27 - Updated API documentation

--- a/Processor.php
+++ b/Processor.php
@@ -18,6 +18,7 @@ use Piwik\Date;
 use Piwik\Piwik;
 use Piwik\Plugins\API\ProcessedReport;
 use Piwik\Scheduler\RetryableException;
+use Piwik\Plugins\SitesManager\API as SitesManagerApi;
 use Piwik\Site;
 
 /**
@@ -185,6 +186,10 @@ class Processor
             return false;
         }
 
+        if (!$this->hasViewPermissionForAlertOwner($alert, $idSite)) {
+            return false;
+        }
+
         if (!$this->validator->isValidComparableDate($alert['period'], $alert['compared_to'])) {
             // actually it would be nice to log or send a notification or whatever that we have skipped an alert
             return false;
@@ -196,6 +201,17 @@ class Processor
         }
 
         return true;
+    }
+
+    protected function hasViewPermissionForAlertOwner(array $alert, int $idSite): bool
+    {
+        if (empty($alert['login'])) {
+            return false;
+        }
+
+        $idSitesUserHasAccess = SitesManagerApi::getInstance()->getSitesIdWithAtLeastViewAccess($alert['login']);
+
+        return !empty($idSitesUserHasAccess) && in_array($idSite, $idSitesUserHasAccess);
     }
 
     private function reportExists($idSite, $report, $metric)

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "CustomAlerts",
     "description": "Create custom Alerts to be notified of important changes on your website or app! ",
-    "version": "5.3.1",
+    "version": "5.3.2",
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"
     },

--- a/tests/Integration/ProcessorTest.php
+++ b/tests/Integration/ProcessorTest.php
@@ -73,6 +73,11 @@ class CustomProcessor extends Processor
     {
         return parent::restrictMultiSitesReportToAlertOwner($params, $report, $alert);
     }
+
+    public function hasViewPermissionForAlertOwner(array $alert, int $idSite): bool
+    {
+        return parent::hasViewPermissionForAlertOwner($alert, $idSite);
+    }
 }
 
 /**
@@ -544,6 +549,7 @@ class ProcessorTest extends BaseTest
     ) {
         return array(
             'idalert'          => 1,
+            'login'            => 'superUserLogin',
             'period'           => $period,
             'id_sites'         => $idSites,
             'metric_condition' => 'increase_more_than',
@@ -598,6 +604,28 @@ class ProcessorTest extends BaseTest
         $alert = $this->buildAlert();
 
         $this->assertProcessNotRun($alert, array(99, 85));
+    }
+
+    public function test_processAlert_shouldNotRun_IfAlertOwnerNoLongerHasViewAccess()
+    {
+        $alert = $this->buildAlert([1]);
+
+        $processorMock = $this->getMockBuilder('Piwik\Plugins\CustomAlerts\tests\Integration\CustomProcessor')
+            ->setMethods(['hasViewPermissionForAlertOwner', 'getValueForAlertInPast', 'triggerAlert'])
+            ->getMock();
+
+        $processorMock->expects($this->once())
+            ->method('hasViewPermissionForAlertOwner')
+            ->with($this->equalTo($alert), $this->equalTo(1))
+            ->will($this->returnValue(false));
+
+        $processorMock->expects($this->never())
+            ->method('getValueForAlertInPast');
+
+        $processorMock->expects($this->never())
+            ->method('triggerAlert');
+
+        $processorMock->processAlert($alert, 1);
     }
 
     public function test_processAlert_shouldOnlyBeTriggeredIfAlertMatches()


### PR DESCRIPTION
## Description
Adds code to improve the access check before sending an alert

## Issue No
#AS-586

## Steps to Replicate the Issue
1.



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
