### PR TITLE
Fix failing tests on 5.x-dev [no_release]

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "description": "Create custom Alerts to be notified of important changes on your website or app! ",
     "version": "5.3.2",
     "require": {
-        "matomo": ">=5.0.0-b1,<6.0.0-b1"
+        "matomo": ">=5.6.0,<6.0.0-b1"
     },
     "authors": [
         {


### PR DESCRIPTION
## Description
Automated fix for failing tests on `5.x-dev`.

- Failing workflow: Plugin CustomAlerts Tests
- Failing job(s): PluginTests (matomo5_min_php, minimum_required_matomo), PluginTests (matomo5_max_php, minimum_required_matomo)
- CI run: https://github.com/matomo-org/plugin-CustomAlerts/actions/runs/28277746760

Generated by automated-test-fixes.

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔/✖] Tested locally or on demo2/demo3?
- [✔/✖/NA] New test case added/updated?
- [✔/✖/NA] Are all newly added texts included via translation?
- [✔/✖/NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔/✖/NA] Version bumped?
- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules
- [✔/✖/NA] Documentation updated?