### PR TITLE
Call the shared PHPCS, PHPStan and AI checklist workflows [ignore_release]

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,10 @@
+name: License check
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  license-check:
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-license-check.yml@main

--- a/.github/workflows/matomo-ai-checklist.yml
+++ b/.github/workflows/matomo-ai-checklist.yml
@@ -1,5 +1,3 @@
-# Action for running tests
-
 name: AI Checklist
 
 on:
@@ -8,15 +6,7 @@ on:
 
 permissions:
   actions: read
-  checks: none
-  contents: none
-  deployments: none
-  issues: none
-  packages: none
   pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: none
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,9 +14,6 @@ concurrency:
 
 jobs:
   AiChecklist:
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Run tests
-        uses: matomo-org/github-action-checklist-gate@main
+    # Pinned to the plugin-ci-workflows pull request branch for the pilot;
+    # switch to @main once matomo-org/plugin-ci-workflows#2 merges.
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-ai-checklist.yml@add-plugin-quality-workflows

--- a/.github/workflows/matomo-ai-checklist.yml
+++ b/.github/workflows/matomo-ai-checklist.yml
@@ -14,6 +14,4 @@ concurrency:
 
 jobs:
   AiChecklist:
-    # Pinned to the plugin-ci-workflows pull request branch for the pilot;
-    # switch to @main once matomo-org/plugin-ci-workflows#2 merges.
-    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-ai-checklist.yml@add-plugin-quality-workflows
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-ai-checklist.yml@main

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,41 +3,12 @@ name: PHPCS check
 on: pull_request
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: none
-  issues: read
-  packages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: read
 
 jobs:
   phpcs:
-    name: PHPCS
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: false
-          persist-credentials: false
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          tools: cs2pr
-      - name: Install dependencies
-        run:
-          composer init --name=matomo/customalerts --quiet;
-          composer --no-plugins config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true -n;
-          composer config repositories.matomo-coding-standards vcs https://github.com/matomo-org/matomo-coding-standards -n;
-          composer require matomo-org/matomo-coding-standards:dev-master;
-          composer install --dev --prefer-dist --no-progress --no-suggest
-      - name: Check PHP code styles
-        id: phpcs
-        run: ./vendor/bin/phpcs --report-full --standard=phpcs.xml --report-checkstyle=./phpcs-report.xml
-      - name: Show PHPCS results in PR
-        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: cs2pr ./phpcs-report.xml --prepend-filename
+    # Pinned to the plugin-ci-workflows pull request branch for the pilot;
+    # switch to @main once matomo-org/plugin-ci-workflows#2 merges.
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpcs.yml@add-plugin-quality-workflows
+    with:
+      plugin-name: CustomAlerts

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -7,8 +7,6 @@ permissions:
 
 jobs:
   phpcs:
-    # Pinned to the plugin-ci-workflows pull request branch for the pilot;
-    # switch to @main once matomo-org/plugin-ci-workflows#2 merges.
-    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpcs.yml@add-plugin-quality-workflows
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpcs.yml@main
     with:
       plugin-name: CustomAlerts

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,10 +7,7 @@ permissions:
 
 jobs:
   phpstan:
-    # Pinned to the plugin-ci-workflows pull request branch for the pilot;
-    # switch to @main and drop workflows-ref once matomo-org/plugin-ci-workflows#2 merges.
-    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpstan.yml@add-plugin-quality-workflows
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpstan.yml@main
     with:
       plugin-name: CustomAlerts
-      workflows-ref: add-plugin-quality-workflows
     secrets: inherit

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,81 +3,14 @@ name: PHPStan check
 on: pull_request
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: none
-  issues: read
-  packages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: read
-
-env:
-  PLUGIN_NAME: CustomAlerts
 
 jobs:
   phpstan:
-    name: PHPStan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: false
-          persist-credentials: false
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-
-      - name: Check out github-action-tests repository
-        uses: actions/checkout@v4
-        with:
-          repository: matomo-org/github-action-tests
-          ref: main
-          path: github-action-tests
-
-      - name: checkout matomo for plugin builds
-        shell: bash
-        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_matomo.sh
-        env:
-          PLUGIN_NAME: ${{ env.PLUGIN_NAME }}
-          WORKSPACE: ${{ github.workspace }}
-          ACTION_PATH: ${{ github.workspace }}/github-action-tests
-          MATOMO_TEST_TARGET: maximum_supported_matomo
-
-      - name: prepare setup
-        shell: bash
-        run: |
-          cd ${{ github.workspace }}/matomo
-          echo -e "composer install"
-          composer install --ignore-platform-reqs
-
-      - name: checkout additional plugins
-        if: ${{ env.DEPENDENT_PLUGINS != '' }}
-        shell: bash
-        working-directory: ${{ github.workspace }}/matomo
-        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_dependent_plugins.sh
-
-        env:
-          GITHUB_USER_TOKEN: ${{ secrets.TESTS_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: "Restore result cache"
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/phpstan # same as in phpstan.neon
-          key: "phpstan-result-cache-${{ github.run_id }}"
-          restore-keys: |
-            phpstan-result-cache-
-
-      - name: PHPStan whole repo
-        id: phpstan-all
-        run: cd ${{ github.workspace }}/matomo && composer run phpstan -- -vvv -c plugins/${{ env.PLUGIN_NAME }}/phpstan.neon
-
-      - name: "Save result cache"
-        uses: actions/cache/save@v4
-        if: ${{ !cancelled() }}
-        with:
-          path: /tmp/phpstan # same as in phpstan.neon
-          key: "phpstan-result-cache-${{ github.run_id }}"
+    # Pinned to the plugin-ci-workflows pull request branch for the pilot;
+    # switch to @main and drop workflows-ref once matomo-org/plugin-ci-workflows#2 merges.
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpstan.yml@add-plugin-quality-workflows
+    with:
+      plugin-name: CustomAlerts
+      workflows-ref: add-plugin-quality-workflows
+    secrets: inherit


### PR DESCRIPTION
## Description

Pilot for the shared plugin CI workflows in matomo-org/plugin-ci-workflows, and the first public repository to call them. Replaces this plugin's own copies of the PHPCS, PHPStan and AI checklist workflows with calls to the shared definitions: 124 lines of duplicated CI removed for 15 lines of caller.

All three are pinned to the pull request branch of matomo-org/plugin-ci-workflows#2 so this pilot proves them on a runner before that merges. Once it does, the refs change to `@main` and `workflows-ref` drops out, leaving each caller as the shared workflow plus the plugin name.

No input other than `plugin-name` is needed here: this plugin is on the Matomo 5 line, which is what the shared defaults already target.

The shared PHPStan workflow analyses against the oldest supported Matomo as well as the newest, where the previous copy only checked the newest. Any new findings on that leg are the point of the change rather than a regression.

No version bump or changelog entry: this is CI-only.

## Issue No

Related to PG-4897

## Steps to Replicate the Issue

NA — CI change.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
